### PR TITLE
Fix HTML Response Parsing Broken By Cyberrealm Changes

### DIFF
--- a/Release/scripts/Helix Fossil/Pocket Familiars.ash
+++ b/Release/scripts/Helix Fossil/Pocket Familiars.ash
@@ -4555,7 +4555,7 @@ PocketFamiliar PocketFamiliarParseFamiliarFromText(string table_text)
 PocketFamiliarFightStatus PocketFamiliarsParsePage(buffer page_text)
 {
 	PocketFamiliarFightStatus status;
-    if (!page_text.contains_text("<b>Fight!</b></td></tr>"))
+    if (!page_text.contains_text(">Fight!</b></td></tr>"))
         return status;
 	string [int][int] table_matches = page_text.group_string("<table class(.*?)</table>");
 	
@@ -4899,7 +4899,7 @@ PocketFamiliarMoveStats PocketFamiliarCalculateMoveStats(string move, PocketFami
 
 buffer PocketFamiliarsFightRound(buffer page_text)
 {
-    if (!page_text.contains_text("<b>Fight!</b></td></tr>"))
+    if (!page_text.contains_text(">Fight!</b></td></tr>"))
     	return page_text;
     PocketFamiliarFightStatus status = PocketFamiliarsParsePage(page_text);
     string chosen_move_name;
@@ -5018,7 +5018,7 @@ buffer PocketFamiliarsFight(boolean from_relay)
 	{
 		breakout -= 1;
         page_text = PocketFamiliarsFightRound(page_text);
-        if (!page_text.contains_text("<b>Fight!</b></td></tr>"))
+        if (!page_text.contains_text(">Fight!</b></td></tr>"))
         	break;
         if (page_text.contains_text("<!--WINWINWIN-->"))
         {


### PR DESCRIPTION
The release of Cyberrealm in January of 2025 changed some of HTML kingdom wide. Apparently, one of the things that changed was the opening `<b>` tag just before the word `Fight!` in the title of the combats.

The minor HTML changes cause the `Pocket Familiars.ash` script to return silently without doing anything, since the page doesn't look like a valid Pocket Familiars combat response as it expects it. Autoscend breaks when it calls the script and this happens, because the combat code in autoscend repeats the call until it thinks 25 rounds of combat have passed, at which point it aborts.

Simply removing the initial `<b` portion of the substring checks in the 3 places they appear seems to fix the issue. The updated HTML when the matrix-style green on black color scheme (available through a Cyberrealm derived item) isn't active is `<b style="color: white">Fight!</b>`. The color value is presumably consistently something else when it's not white, but just not checking the whole opening tag seemed like a simpler solution and appears to work fine.